### PR TITLE
Sqwish will incorrectly collapse certain longhand-specified values

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -50,10 +50,10 @@ function sqwish(css, strict) {
     .replace(/#([a-fA-F0-9])\1([a-fA-F0-9])\2([a-fA-F0-9])\3/g, '#$1$2$3')
 
     // replace longhand values with shorthand '5px 5px 5px 5px' => '5px'
-    .replace(/(\d+[a-z]{2}) \1 \1 \1/gi, '$1')
+    .replace(/\b(\d+[a-z]{2}) \1 \1 \1/gi, '$1')
 
     // replace double-specified longhand values with shorthand '5px 2px 5px 2px' => '5px 2px'
-    .replace(/(\d+[a-z]{2}) (\d+[a-z]{2}) \1 \2/gi, '$1 $2')
+    .replace(/\b(\d+[a-z]{2}) (\d+[a-z]{2}) \1 \2/gi, '$1 $2')
 
     // replace 0px with 0
     .replace(/([\s|:])[0]+px/g, '$10')

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -26,6 +26,20 @@ sink('basic mode', function (test, ok) {
     ok(actual == expected, 'collapsed 0px 1px 0px 1px to 0 1px')
   })
 
+  test('certain longhand values are maintained', 1, function () {
+    var input = 'p { margin: 11px 1px 1px 1px }'
+      , expected = 'p{margin:11px 1px 1px 1px}'
+      , actual = sqwish.minify(input)
+    ok(actual == expected, 'maintained 11px 1px 1px 1px')
+  })
+
+  test('certain double-specified longhand values are maintained', 1, function () {
+    var input = 'p { margin: 12px 12px 2px 12px }'
+      , expected = 'p{margin:12px 12px 2px 12px}'
+      , actual = sqwish.minify(input)
+    ok(actual == expected, 'maintained 12px 12px 2px 12px')
+  })
+
   test('does not break with @media queries', 2, function () {
     var input = '@media screen and (max-device-width: 480px) {' +
                 '  .column {' +


### PR DESCRIPTION
For example `15px 15px 5px 15px` in the current version will get collapsed to `15px 15px` because the regular expression ignores the first `1`.  This fix anchors the replacement RegExp at the beginning of the specifier to prevent the issue.
