### PR TITLE
Sqwish is wrongfully shortening hex IE numbers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -47,7 +47,7 @@ function sqwish(css, strict) {
     .replace(/\s+(!important)/g, '$1')
 
     // convert longhand hex to shorthand hex
-    .replace(/#([a-fA-F0-9])\1([a-fA-F0-9])\2([a-fA-F0-9])\3/g, '#$1$2$3')
+    .replace(/#([a-fA-F0-9])\1([a-fA-F0-9])\2([a-fA-F0-9])\3(?![a-fA-F0-9])/g, '#$1$2$3')
 
     // replace longhand values with shorthand '5px 5px 5px 5px' => '5px'
     .replace(/\b(\d+[a-z]{2}) \1 \1 \1/gi, '$1')

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -19,6 +19,13 @@ sink('basic mode', function (test, ok) {
     ok(actual == expected, 'collapsed #ffcc33 to #fc3')
   })
 
+  test('IE long hex is kept as long hex', 1, function () {
+    var input = "body { filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFF2F2F2', endColorstr='#FFFFFFFF'); }"
+      , expected = "body{filter:progid:DXImageTransform.Microsoft.gradient(gradientType=0,startColorstr='#FFF2F2F2',endColorstr='#FFFFFFFF')}"
+      , actual = sqwish.minify(input)
+    ok(actual == expected, 'IE long hexes are kept that way')
+  })
+
   test('longhand values to shorthand values', 1, function () {
     var input = 'p { margin: 0px 1px 0px 1px }'
       , expected = 'p{margin:0 1px}'


### PR DESCRIPTION
...ly being shortened by sqwish. This change uses a negative lookahead to make sure the RGB is not followed by another HEX number.
