### PR TITLE
ie-specific property

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,10 @@ function uniq(ar) {
   }
   return a
 }
+function escapeRegExp(str) {
+  return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
+}
+
 
 function sqwish(css, strict) {
   // allow /*! bla */ style comments to retain copyrights etc.
@@ -97,7 +101,7 @@ function strict_css(css) {
       // pre-existing properties are not wanted anymore
       return !declarations.some(function (dec) {
         // must include '^' as to not confuse "color" with "border-color" etc.
-        return dec.match(new RegExp('^' + prop + ':'))
+        return dec.match(new RegExp('^' + escapeRegExp(prop) + ':'))
       })
     })
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -54,12 +54,6 @@ sink('basic mode', function (test, ok) {
 
   })
 
-  test('ie-specific properties *prop', 1, function() {
-    var input = '.class {*display:block; display:inline-block;}'
-      ,expected = '.class{*display:block;display:inline-block}'
-    ok(sqwish.minify(input) == expected, 'ie-specific properties are tolerated')
-  })
-
 })
 
 sink('strict mode', function (test, ok) {
@@ -75,6 +69,13 @@ sink('strict mode', function (test, ok) {
       , expected = 'div{color:#fc8}'
       , actual = sqwish.minify(input, true)
     ok(actual == expected, 'collapsed duplicate into a single declaration')
+  })
+
+  test('ie-specific properties *prop', 1, function() {
+    var input = '.class {*display:block; display:inline-block;}'
+      ,expected = '.class{display:inline-block;*display:block}'
+      console.log(sqwish.minify(input,true));
+    ok(sqwish.minify(input,true) == expected, 'ie-specific properties are tolerated')
   })
 
 })

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -54,6 +54,12 @@ sink('basic mode', function (test, ok) {
 
   })
 
+  test('ie-specific properties *prop', 1, function() {
+    var input = '.class {*display:block; display:inline-block;}'
+      ,expected = '.class{*display:block;display:inline-block}'
+    ok(sqwish.minify(input) == expected, 'ie-specific properties are tolerated')
+  })
+
 })
 
 sink('strict mode', function (test, ok) {


### PR DESCRIPTION
.class {
*display:block;
}

caused error: SyntaxError: Invalid regular expression: /^*display:/: Nothing to repeat

now it compiles fine.
