### PR TITLE
fix npm WARN package.json sqwish@0.2.1 No repository field.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,11 @@
       "test": "node tests/tests.js"
     }
   , "preferGlobal": true
+  , "repository" : { 
+      "type" : "git"
+      , "url" : "https://github.com/ded/sqwish.git"
+    }
+
   , "bin": {
       "sqwish": "bin/sqwish"
     }


### PR DESCRIPTION
"New check as of NPM v1.2.20, they report this as a warning."
http://stackoverflow.com/questions/16827858/npm-warn-package-json
https://npmjs.org/doc/json.html#repository
