### PR TITLE
update package.json to prevent warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
     "css",
     "compress"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/ded/sqwish.git"
+  },
   "main": "src/index.js",
   "engines": {
     "node": ">= 0.4.1"


### PR DESCRIPTION
as of NPM v1.2.20, npm reports warning when repository is missing.
